### PR TITLE
Added formatting to log messages, log levels for info, warn, error

### DIFF
--- a/Assets/Bandsaw/Scripts/Editor/BandsawLogViews.cs
+++ b/Assets/Bandsaw/Scripts/Editor/BandsawLogViews.cs
@@ -5,10 +5,48 @@ namespace Bandsaw
 {
     public static class BandsawLogViews
     {
-        private static GUILayoutOption[] logLineOptions = { GUILayout.Height(20) };
-        public static void LogLineView(Log log)
+        private const int LINE_HEIGHT = 30;
+        private const int TAG_WIDTH = 150;
+        private static GUIStyle tagStyle = new GUIStyle(EditorStyles.boldLabel);
+        private static GUIStyle levelStyle = new GUIStyle(EditorStyles.boldLabel);
+        private static GUIStyle messageStyle = new GUIStyle(EditorStyles.label);
+        private static GUILayoutOption[] logLineOptions = { GUILayout.Height(LINE_HEIGHT) };
+        private static GUILayoutOption[] logLevelOptions = { GUILayout.Height(LINE_HEIGHT), GUILayout.Width(30), GUILayout.ExpandWidth(false) };
+        private static GUILayoutOption[] logTagOptions = { GUILayout.Height(LINE_HEIGHT), GUILayout.Width(TAG_WIDTH) };
+
+
+        public static void LogLineView(Log log, int pos)
         {
-            EditorGUILayout.LabelField(log.content, logLineOptions);
+
+            var bg = new Color32(44, 44, 44, 50);
+            var r = EditorGUILayout.BeginHorizontal();
+
+            //EditorGUI.DrawRect(new Rect(0, pos, r.width + 50, LINE_HEIGHT), bg);
+
+            ShowLogLevelField(log.level);
+            EditorGUILayout.LabelField(log.tag, tagStyle, logTagOptions);
+            EditorGUILayout.LabelField(log.content, messageStyle, logLineOptions);
+            EditorGUILayout.EndHorizontal();
+        }
+
+        private static void ShowLogLevelField(LogLevel level)
+        {
+            var letter = string.Empty;
+            switch (level)
+            {
+                case LogLevel.Info:
+                    letter = "I";
+                    break;
+                case LogLevel.Warn:
+                    letter = "W";
+                    break;
+                case LogLevel.Error:
+                    letter = "E";
+                    break;
+            }
+
+            levelStyle.alignment = TextAnchor.MiddleCenter;
+            EditorGUILayout.LabelField(letter, levelStyle, logLevelOptions);
         }
     }
 

--- a/Assets/Bandsaw/Scripts/Editor/BandsawWindow.cs
+++ b/Assets/Bandsaw/Scripts/Editor/BandsawWindow.cs
@@ -15,7 +15,7 @@ namespace Bandsaw
         {
             scrollPosition = new Vector2(0, logs.Count * 20);
             scrollPosition = EditorGUILayout.BeginScrollView(scrollPosition);
-            logs.ForEach(l => BandsawLogViews.LogLineView(l));
+            logs.ForEach(l => BandsawLogViews.LogLineView(l, (logs.Count - 1) * 20));
             EditorGUILayout.EndScrollView();
         }
 

--- a/Assets/Bandsaw/Scripts/Editor/Log.cs
+++ b/Assets/Bandsaw/Scripts/Editor/Log.cs
@@ -8,10 +8,14 @@ public class Log
     public string tag;
     [SerializeField]
     public string content;
+    [SerializeField]
+    public LogLevel level;
 
-    public Log(string tag, string content)
+
+    public Log(LogLevel level, string tag, string content)
     {
         this.tag = tag;
         this.content = content;
+        this.level = level;
     }
 }

--- a/Assets/Bandsaw/Scripts/Editor/LogLevel.cs
+++ b/Assets/Bandsaw/Scripts/Editor/LogLevel.cs
@@ -1,0 +1,4 @@
+public enum LogLevel
+{
+    Info, Warn, Error
+}

--- a/Assets/Bandsaw/Scripts/Editor/LogLevel.cs.meta
+++ b/Assets/Bandsaw/Scripts/Editor/LogLevel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 41dec145697f80849a8170585bbcd463
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Bandsaw/Scripts/LogTestBehavior.cs
+++ b/Assets/Bandsaw/Scripts/LogTestBehavior.cs
@@ -9,6 +9,8 @@ public class LogTestBehavior : MonoBehaviour
     void Start()
     {
         Saw.Log("LogTestBehavior", "Test log STRANGGGG!");
+        Saw.Warn("LogTestBehavior", "It's a warning bro!");
+        Saw.Error("LogTestBehavior", "It's a BIG ERROR!");
     }
 
     // Update is called once per frame

--- a/Assets/Bandsaw/Scripts/Logging/Saw.cs
+++ b/Assets/Bandsaw/Scripts/Logging/Saw.cs
@@ -11,7 +11,23 @@ namespace Bandsaw
         {
             logger.Log(tag, message);
 
-            var log = new Log(tag, message);
+            var log = new Log(LogLevel.Info, tag, message);
+            BandsawWindow.SubmitLog(log);
+        }
+
+        public static void Warn(string tag, string message)
+        {
+            logger.Log(tag, message);
+
+            var log = new Log(LogLevel.Warn, tag, message);
+            BandsawWindow.SubmitLog(log);
+        }
+
+        public static void Error(string tag, string message)
+        {
+            logger.Log(tag, message);
+
+            var log = new Log(LogLevel.Error, tag, message);
             BandsawWindow.SubmitLog(log);
         }
     }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
     "com.unity.collab-proxy": "1.2.16",
-    "com.unity.ide.rider": "1.1.4",
     "com.unity.ide.vscode": "1.2.2",
     "com.unity.test-framework": "1.1.13",
     "com.unity.textmeshpro": "2.0.1",


### PR DESCRIPTION
This feature:

- Adds basic formatting to the log window
- Denotes log messages with their log level in the ui - **I**, **W**, or **E**
- Added support to trigger these via `Saw.Log()`, `Saw.Warn()`, and `Saw.Error()`